### PR TITLE
Fix memory inefficiency for baseline (GPTQ) configuration

### DIFF
--- a/lm-evaluation-harness/lm_eval/quantization/spqr/spqr.py
+++ b/lm-evaluation-harness/lm_eval/quantization/spqr/spqr.py
@@ -144,7 +144,7 @@ class SPQRUtil:
                     group_weight = weight[:, column_index: column_index + groupsize]
                     group_mask = 1 - outlier_columns_mask[column_index: column_index + groupsize].float()
 
-                    if simplified_outliers:
+                    if simplified_outliers or (unstructured_outlier_threshold == float("inf")):
                         quantizer.find_params(group_weight * group_mask, weight=True)
                     else:
                         # objective: detect which weights will be designated as outliers, fit quantizer *without* these weights

--- a/spqr_engine.py
+++ b/spqr_engine.py
@@ -123,7 +123,7 @@ class SPQRUtil:
                     in_group_index += 1
                     group_weight = weight[:, column_index : column_index + groupsize]
 
-                    if simplified_outliers:
+                    if simplified_outliers or (unstructured_outlier_threshold == float("inf")):
                         quantizer.find_params(group_weight, weight=True)
 
                     else:


### PR DESCRIPTION
This PR resolves an issue found by @poedator : the GPTQ baseline with very large group size would previously try to find outliers - and waste memory doing so - even though the outlier threshold is infinite