### PR TITLE
refactor of datautils

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,9 @@ __Note:__ the results reported in the ArXiv paper where obtained using `4.28.dev
 
 ### Loading / caching datasets and tokenizer
 
-The script will require downloading and caching locally the relevant tokenizer and the datasets. They will be saved in `$TRANSFORMERS_CACHE` directory.
-
+The script will require downloading and caching locally the relevant tokenizer and the datasets. 
+They will be saved in default Huggingface Datasets directory unless alternative location is provided by env variables.
+See [relevant Datasets documentation section](https://huggingface.co/docs/datasets/main/en/cache#cache-directory)
 ### Models
 
 This repository is expected to work with models of `LLaMA` and `Falcon` families so far.
@@ -32,7 +33,7 @@ This repository is expected to work with models of `LLaMA` and `Falcon` families
 
 For quantization with SpQR its is recommended to use the subset of the data model 
 was trained on. I.e. for quantization of `LLaMA` models we recommend to use the subset
-of [RedPajamas](https://huggingface.co/datasets/togethercomputer/RedPajama-Data-1T-Sample) and for `Falcon` quantization - [RefinedWeb](https://huggingface.co/datasets/tiiuae/falcon-refinedweb). Both subsets 
+of [RedPajama](https://huggingface.co/datasets/togethercomputer/RedPajama-Data-1T-Sample) and for `Falcon` quantization - [RefinedWeb](https://huggingface.co/datasets/tiiuae/falcon-refinedweb). Both subsets 
 are stored in `data` directory: 
 * `data/red_pajama_n=1024.pth`
 * `data/refined_web_n=128.pth`
@@ -63,10 +64,9 @@ The command to launch the script should look like this:
 
 ```
 export MODEL_PATH=<PATH_TO_MODEL_DIR>
-export CUSTOM_DATA_PATH=<INSERT PATH TO CUSTOM DATA>
+export DATASET=<INSERT DATASET NAME OR PATH TO CUSTOM DATA>
 
-python main.py $MODEL_PATH custom \
-    --custom_data_path=$CUSTOM_DATA_PATH \
+python main.py $MODEL_PATH $DATASET \
     --wbits 4 \
     --groupsize 16 \
     --perchannel \
@@ -82,8 +82,7 @@ The command above runs near-lossless compression as described in the article. Ad
 
 Note the launch arguments:
 - `<PATH_TO_MODEL_DIR>` - path to model folder, which contains `config.json `
-- `one of [c4, ptb, wikitext2, custom]` -- name of dataset to use for compression
-- `--custom_data_path` - path to preprocessed and tokenized dataset (if `custom` chosen). Otherwise do not specify.
+- `one of [c4, ptb, wikitext2, pajama, refinedweb, none]` -- name of dataset to use for compression, or path to an alternative preprocessed and tokenized dataset.
 - `--wbits 3` -- number of bits for quantized weights representation
 - `--groupsize 16` -- size of first-order groups for compression
 - `--qq_groupsize 16` -- size of second-order (quantized) groups for compression
@@ -113,12 +112,12 @@ Below is presented an example of benchmark launch.
 
 ```
 export MODEL_PATH=<INSERT PATH_TO_MODEL_DIR>
-export CUSTOM_DATA_PATH=<INSERT PATH TO CUSTOM DATA>
+export DATASET=<INSERT DATASET NAME OR PATH TO CUSTOM DATA>
 
 python lmeval.py \
     --model hf-causal \
     --model_args pretrained=$MODEL_PATH,dtype=float16,use_accelerate=True \
-    --quantization_args dataset=custom,custom_data_path=$CUSTOM_DATA_PATH,wbits=4,groupsize=16,perchannel=True,qq_scale_bits=3,qq_zero_bits=3,qq_groupsize=16,percdamp=1.0,outlier_threshold=0.2,simplified_outliers=False,nsamples=128,offload_activations=True \
+    --quantization_args dataset=$DATASET,wbits=4,groupsize=16,perchannel=True,qq_scale_bits=3,qq_zero_bits=3,qq_groupsize=16,percdamp=1.0,outlier_threshold=0.2,simplified_outliers=False,nsamples=128,offload_activations=True \
     --tasks winogrande,piqa,hellaswag,arc_easy,arc_challenge \
     --batch_size 1
 ```

--- a/datautils.py
+++ b/datautils.py
@@ -3,6 +3,7 @@ import torch
 import random
 from transformers import AutoTokenizer, LlamaTokenizer
 from datasets import load_dataset
+from warnings import warn
 
 
 def set_seed(seed):
@@ -94,7 +95,7 @@ def get_c4(nsamples, seqlen, tokenizer, new=False, eval_mode=False):
         return valenc
 
 
-def get_loaders(name, nsamples=128, seed=0, seqlen=2048, model_path="", eval_mode=False):
+def get_loaders(name, nsamples=128, seed=0, seqlen=2048, model_path="", eval_mode=False, custom_data_path=None):
     """
     Loads and prepares data for a Transformers model.
     Args:
@@ -149,6 +150,10 @@ def get_loaders(name, nsamples=128, seed=0, seqlen=2048, model_path="", eval_mod
     elif name.lower().startswith("c4"):
         data = get_c4(nsamples, seqlen, tokenizer, new=("new" in name), eval_mode=eval_mode)
     else:
+        if name.lower() == "custom":
+            warn(("Dataset option 'custom' is deprecated. insert dataset path directly or use 'pajama', 'refinedweb'"
+                 "See README for examples."), DeprecationWarning)
+            name = custom_data_path
         try:
             data = torch.load(name)[: nsamples]
         except FileNotFoundError:

--- a/datautils.py
+++ b/datautils.py
@@ -98,17 +98,24 @@ def get_loaders(name, nsamples=128, seed=0, seqlen=2048, model_path="", eval_mod
     """
     Loads and prepares data for a Transformers model.
     Args:
-        name (str): The name of the dataset to load. This can be one of 'wikitext2', 'c4', 'ptb' or 'custom'
-        custom_data_path (str, optional): The path to a custom dataset file. Assumes name=='custom'
+        name (str): The name of the dataset to load.
+        This can be one of 'wikitext2', 'c4', 'ptb' for datasets loaded from Huggingface datasets,
+        'pajama' or 'refinedweb' for pre-tokenized datasets in folder `data` or 'none' for cases
+        where a dataset is not needed, like RTN. It can also accept data path to custom file.
         nsamples (int, optional): The number of samples to load from the dataset. Defaults to 128.
         seed (int, optional): The random seed value for data shuffling and splitting. Defaults to 0.
         seqlen (int, optional): The maximum sequence length for input tokenization. Defaults to 2048.
         model_path (str, optional): The path to the pretrained model weights or full model name.
             used to detect llama to call proper tokenizer.
             see https://github.com/huggingface/transformers/issues/22222#issuecomment-1488578722 for reasons.
+        eval_mode (bool, optional). defines slice selection for 'wikitext2', 'c4', 'ptb' datasets.
+        leave False for train slice.
     Returns:
-        train_loader (torch.utils.data.DataLoader or iterable): DataLoader for the training dataset.
-        test_loader (torch.utils.data.DataLoader or iterable): DataLoader for the test dataset.
+        data (torch.utils.data.DataLoader or iterable): Data iterable for the dataset.
+    Note:
+        the popular decapoda-research Llama models have errors in tokenizer config, specifically
+        incorrect token ids for BOS, EOS. This gets corrected to ensure compatibility with transformers
+        of versions 4.29 and above.
     """
     set_seed(seed)
 

--- a/lmeval.py
+++ b/lmeval.py
@@ -51,7 +51,6 @@ def parse_args():
     parser.add_argument("--device", type=str, default="cuda:0")
     parser.add_argument("--output_path", default=None)
     parser.add_argument("--limit", type=int, default=None)
-    parser.add_argument("--no_cache", action="store_true")
     parser.add_argument("--decontamination_ngrams_path", default=None)
     parser.add_argument("--description_dict_path", default=None)
     parser.add_argument("--check_integrity", action="store_true")
@@ -125,7 +124,7 @@ def main():
         num_fewshot=args.num_fewshot,
         batch_size=args.batch_size,
         device=args.device,
-        no_cache=args.no_cache,
+        no_cache=True,
         limit=args.limit,
         description_dict=description_dict,
         decontamination_ngrams_path=args.decontamination_ngrams_path,

--- a/main.py
+++ b/main.py
@@ -285,6 +285,7 @@ def quantize_spqr(model, dataloader, args, device):
         round_zero=args.round_zero,
         global_ol_n_share=normal_outlier_count_global / w_count_global,
     )
+    print(f"wbits_avg:  {wbits_avg:.3}")
 
     if args.wandb:
         wandb.log({"outlier_share": normal_outlier_count_global / w_count_global})

--- a/main.py
+++ b/main.py
@@ -68,6 +68,7 @@ def quantize_model(model, args, device):
             seed=args.seed,
             model_path=args.model_path,
             seqlen=model.seqlen,
+            custom_data_path=args.custom_data_path,
         )
         results = quantize_spqr(model, dataloader, args, device)
     print(f"quantization time: {time.time() - tick:.1f}")
@@ -382,6 +383,12 @@ if __name__ == "__main__":
         help="Dataset name [c4, pajama, refinedweb, none, etc.] or path to data where to extract calibration data from.",
     )
     parser.add_argument(
+        "--custom_data_path",
+        type=str,
+        default=None,
+        help="Path to load if specified. Deprecated",
+    )
+    parser.add_argument(
         "--seed", type=int, default=0, help="Seed for sampling the calibration data."
     )
     parser.add_argument(
@@ -460,7 +467,6 @@ if __name__ == "__main__":
         default=16,
         help="Quantize quantization scale in groups of this many scales",
     )
-
     parser.add_argument(
         "--outlier_threshold",
         type=float,
@@ -472,7 +478,6 @@ if __name__ == "__main__":
         action="store_true",
         help="do not perform leave-one-out evaluation when detecting outliers; works faster, but generally worse in perplexity",
     )
-
     parser.add_argument(
         "--save_pt",
         type=str,

--- a/main.py
+++ b/main.py
@@ -62,9 +62,8 @@ def quantize_model(model, args, device):
         results = quantize_nearest(model, args, device)
     else:
         print("Loading data ...")
-        dataloader, _ = get_loaders(
+        dataloader = get_loaders(
             args.dataset,
-            custom_data_path=args.custom_data_path,
             nsamples=args.nsamples,
             seed=args.seed,
             model_path=args.model_path,
@@ -83,9 +82,6 @@ def get_inps(model, data_iterable, args, dev, nsamples=None):
     layers = get_layers(model)
 
     nsamples = nsamples or args.nsamples
-
-    if hasattr(data_iterable, 'input_ids'):
-        data_iterable = data_iterable.input_ids
 
     if isinstance(data_iterable, torch.Tensor):
 
@@ -324,9 +320,6 @@ def quantize_nearest(model, args, dev):
 def perplexity_eval(model, testenc, args, dev):
     print(f"\nEvaluating perplexity for {args.dataset_name} dataset ...")
 
-    if hasattr(testenc, 'input_ids'):
-        testenc = testenc.input_ids
-
     nsamples = testenc.numel() // model.seqlen
 
     use_cache = model.config.use_cache
@@ -384,15 +377,8 @@ if __name__ == "__main__":
     parser.add_argument(
         "dataset",
         type=str,
-        choices=["custom", "wikitext2", "ptb", "c4"],
         default="none",
-        help="Where to extract calibration data from.",
-    )
-    parser.add_argument(
-        "--custom_data_path",
-        type=str,
-        default=None,
-        help="Path to load if specified.",
+        help="Dataset name [c4, pajama, refinedweb, none, etc.] or path to data where to extract calibration data from.",
     )
     parser.add_argument(
         "--seed", type=int, default=0, help="Seed for sampling the calibration data."
@@ -552,8 +538,8 @@ if __name__ == "__main__":
     if args.new_eval:
         datasets = ["wikitext2", "ptb-new", "c4-new"]
     for dataset in datasets:
-        dataloader, testloader = get_loaders(
-            dataset, seed=args.seed, model_path=args.model_path, seqlen=model.seqlen
+        testloader = get_loaders(
+            dataset, seed=args.seed, model_path=args.model_path, seqlen=model.seqlen, eval_mode=True,
         )
         args.dataset_name = dataset
         perplexity_eval(model, testloader, args, device)


### PR DESCRIPTION
- fixing bos, eos token ids when loading from decapoda-research llama models - this was cause by incorrect tokenized config and was causing errors with transformers >=4.29.0
- combining old and new eval functions
- separate loading of train and eval data  using param:eval_mode (saves time)
- combining args.dataset and args.custom_data_path into one option
- loading parama and refinedweb using dataset option (since they both are included into this repo in a fixed location)
tests available in the private chat