### PR TITLE
Rollback model loading to match the code from the paper 

### DIFF
--- a/modelutils.py
+++ b/modelutils.py
@@ -7,7 +7,7 @@ MODEL_ERROR_MSG = "Unsupported model type {} - only 'llama' and 'falcon' support
 
 def get_model(model_path, dtype="auto"):
     if dtype == "auto":
-        dtype = AutoConfig.from_pretrained(model_path).torch_dtype or "auto"
+        dtype = AutoConfig.from_pretrained(model_path).torch_dtype or "auto"  # force transformers 4.29.2 to follow the same rules as 4.30.x
     else:
         dtype = getattr(torch, dtype)
 

--- a/modelutils.py
+++ b/modelutils.py
@@ -8,13 +8,18 @@ MODEL_ERROR_MSG = "Unsupported model type {} - only 'llama' and 'falcon' support
 def get_model(model_path, dtype="auto"):
     if dtype != "auto":
         dtype = getattr(torch, dtype)
+    def skip(*args, **kwargs):
+        pass
+
+    saved_inits = torch.nn.init.kaiming_uniform_, torch.nn.init.uniform_, torch.nn.init.normal_  # preserving
+    torch.nn.init.kaiming_uniform_ = torch.nn.init.uniform_ = torch.nn.init.normal_ = skip
     model = AutoModelForCausalLM.from_pretrained(
         pretrained_model_name_or_path=model_path,
         trust_remote_code=True,
         torch_dtype=dtype,
-        low_cpu_mem_usage=True,  # see https://stackoverflow.com/questions/76356591
     )
     model.seqlen = 2048
+    torch.nn.init.kaiming_uniform_, torch.nn.init.uniform_, torch.nn.init.normal_ = saved_inits  # restoring
     return model
 
 

--- a/modelutils.py
+++ b/modelutils.py
@@ -1,13 +1,16 @@
 import torch
 import torch.nn as nn
-from transformers import AutoModelForCausalLM
+from transformers import AutoConfig, AutoModelForCausalLM
 
 MODEL_ERROR_MSG = "Unsupported model type {} - only 'llama' and 'falcon' supported"
 
 
 def get_model(model_path, dtype="auto"):
-    if dtype != "auto":
+    if dtype == "auto":
+        dtype = AutoConfig.from_pretrained(model_path).torch_dtype or "auto"
+    else:
         dtype = getattr(torch, dtype)
+
     def skip(*args, **kwargs):
         pass
 


### PR DESCRIPTION
This code fixes bad perplexity that was found with the following config

```CUDA_VISIBLE_DEVICES=3 OMP_NUM_THREADS=16 MKL_NUM_THREADS=16 python main.py decapoda-research/llama-7b-hf custom --custom_data_path data/red_pajama_n=1024.pth --nsamples 128 --wbits 3 --perchannel --percdamp 1.0 --groupsize 16 --qq_scale_bits 3 --qq_zero_bits 3 --qq_groupsize 64 --outlier_threshold=0.7 --permutation_order act_order```

... and with all dependency versions set by `requirements.txt`


p.s. kind thanks to the authors (esp. @Godofnothing @Vahe1994 ) for helping me figure out what was causing the problem

