### PR TITLE
fixed RefinedWeb vs RefinedWebModel in modelutils.py and main.py

### DIFF
--- a/main.py
+++ b/main.py
@@ -108,7 +108,7 @@ def get_inps(model, data_iterable, args, dev, nsamples=None):
     inps = torch.zeros((nsamples, model.seqlen, model.config.hidden_size), dtype=dtype, device=dev)
 
     forward_arg_names = ["attention_mask",]
-    if model.config.model_type == "RefinedWebModel":
+    if model.config.model_type.lower() in FALCON_TYPES:
         forward_arg_names.append("alibi")
 
     cache = {"i": 0, "attention_mask": None, "alibi": None}

--- a/modelutils.py
+++ b/modelutils.py
@@ -8,7 +8,7 @@ FALCON_TYPES = ("falcon", "refinedweb", "refinedwebmodel")
 
 def get_model(model_path, dtype="auto"):
     if dtype == "auto":
-        dtype = AutoConfig.from_pretrained(model_path).torch_dtype or "auto"  # force transformers 4.29.2 to follow the same rules as 4.30.x
+        dtype = AutoConfig.from_pretrained(model_path, trust_remote_code=True).torch_dtype or "auto"  # force transformers 4.29.2 to follow the same rules as 4.30.x
     else:
         dtype = getattr(torch, dtype)
 


### PR DESCRIPTION
1) apparently falcon models have inconsistent information in field `model_type` of `config.json`. Encountered both `RefinedWebModel` and `RefinedWeb`. 
This PR allows both these values as well as prospective value`Falcon`.

2) added `trust_remote_code=True` to AutoConfig loading, consistent with trust_remote_code param in model loading. (used with Falcon)