### PR TITLE
Drop --no_cache arg in lmeval.py

### DIFF
--- a/lmeval.py
+++ b/lmeval.py
@@ -51,7 +51,6 @@ def parse_args():
     parser.add_argument("--device", type=str, default="cuda:0")
     parser.add_argument("--output_path", default=None)
     parser.add_argument("--limit", type=int, default=None)
-    parser.add_argument("--no_cache", action="store_true")
     parser.add_argument("--decontamination_ngrams_path", default=None)
     parser.add_argument("--description_dict_path", default=None)
     parser.add_argument("--check_integrity", action="store_true")
@@ -125,7 +124,7 @@ def main():
         num_fewshot=args.num_fewshot,
         batch_size=args.batch_size,
         device=args.device,
-        no_cache=args.no_cache,
+        no_cache=True,
         limit=args.limit,
         description_dict=description_dict,
         decontamination_ngrams_path=args.decontamination_ngrams_path,


### PR DESCRIPTION
--no_cache was always needed. Without this option the code would fail due to incompatibility in lm-eval-harness. 
In `lm_eval/evaluate` `simple_evaluate()` accepts model or string with model name. However [here in the if branch without no_cache](https://github.com/Vahe1994/SpQR/blob/main/lm-evaluation-harness/lm_eval/evaluator.py#L93) the code adds model to string. Since always pass loaded model there - adding it to string causes error. This is an issue in the older lm-eval harness code that we copied here. So I hardcoded it to be always True.

In the latest LM-eval code this error [is already fixed with my commit](https://github.com/EleutherAI/lm-evaluation-harness/commit/811252b8af6e74f65ffc94c0467881eb3b8b97fd).