### PR TITLE
[DRAFT] Datautils upd 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,9 @@ __Note:__ the results reported in the ArXiv paper where obtained using `4.28.dev
 
 ### Loading / caching datasets and tokenizer
 
-The script will require downloading and caching locally the relevant tokenizer and the datasets. They will be saved in `$TRANSFORMERS_CACHE` directory.
-
+The script will require downloading and caching locally the relevant tokenizer and the datasets. 
+They will be saved in default Huggingface Datasets directory unless alternative location is provided by env variables.
+See [relevant Datasets documentation section](https://huggingface.co/docs/datasets/main/en/cache#cache-directory)
 ### Models
 
 This repository is expected to work with models of `LLaMA` and `Falcon` families so far.
@@ -32,7 +33,7 @@ This repository is expected to work with models of `LLaMA` and `Falcon` families
 
 For quantization with SpQR its is recommended to use the subset of the data model 
 was trained on. I.e. for quantization of `LLaMA` models we recommend to use the subset
-of [RedPajamas](https://huggingface.co/datasets/togethercomputer/RedPajama-Data-1T-Sample) and for `Falcon` quantization - [RefinedWeb](https://huggingface.co/datasets/tiiuae/falcon-refinedweb). Both subsets 
+of [RedPajama](https://huggingface.co/datasets/togethercomputer/RedPajama-Data-1T-Sample) and for `Falcon` quantization - [RefinedWeb](https://huggingface.co/datasets/tiiuae/falcon-refinedweb). Both subsets 
 are stored in `data` directory: 
 * `data/red_pajama_n=1024.pth`
 * `data/refined_web_n=128.pth`
@@ -63,10 +64,9 @@ The command to launch the script should look like this:
 
 ```
 export MODEL_PATH=<PATH_TO_MODEL_DIR>
-export CUSTOM_DATA_PATH=<INSERT PATH TO CUSTOM DATA>
+export DATASET=<INSERT DATASET NAME OR PATH TO CUSTOM DATA>
 
-python main.py $MODEL_PATH custom \
-    --custom_data_path=$CUSTOM_DATA_PATH \
+python main.py $MODEL_PATH $DATASET \
     --wbits 4 \
     --groupsize 16 \
     --perchannel \
@@ -82,8 +82,7 @@ The command above runs near-lossless compression as described in the article. Ad
 
 Note the launch arguments:
 - `<PATH_TO_MODEL_DIR>` - path to model folder, which contains `config.json `
-- `one of [c4, ptb, wikitext2, custom]` -- name of dataset to use for compression
-- `--custom_data_path` - path to preprocessed and tokenized dataset (if `custom` chosen). Otherwise do not specify.
+- `one of [c4, ptb, wikitext2, pajama, refinedweb, none]` -- name of dataset to use for compression, or path to an alternative preprocessed and tokenized dataset.
 - `--wbits 3` -- number of bits for quantized weights representation
 - `--groupsize 16` -- size of first-order groups for compression
 - `--qq_groupsize 16` -- size of second-order (quantized) groups for compression
@@ -113,12 +112,12 @@ Below is presented an example of benchmark launch.
 
 ```
 export MODEL_PATH=<INSERT PATH_TO_MODEL_DIR>
-export CUSTOM_DATA_PATH=<INSERT PATH TO CUSTOM DATA>
+export DATASET=<INSERT DATASET NAME OR PATH TO CUSTOM DATA>
 
 python lmeval.py \
     --model hf-causal \
     --model_args pretrained=$MODEL_PATH,dtype=float16,use_accelerate=True \
-    --quantization_args dataset=custom,custom_data_path=$CUSTOM_DATA_PATH,wbits=4,groupsize=16,perchannel=True,qq_scale_bits=3,qq_zero_bits=3,qq_groupsize=16,percdamp=1.0,outlier_threshold=0.2,simplified_outliers=False,nsamples=128,offload_activations=True \
+    --quantization_args dataset=$DATASET,wbits=4,groupsize=16,perchannel=True,qq_scale_bits=3,qq_zero_bits=3,qq_groupsize=16,percdamp=1.0,outlier_threshold=0.2,simplified_outliers=False,nsamples=128,offload_activations=True \
     --tasks winogrande,piqa,hellaswag,arc_easy,arc_challenge \
     --batch_size 1
 ```

--- a/main.py
+++ b/main.py
@@ -62,9 +62,8 @@ def quantize_model(model, args, device):
         results = quantize_nearest(model, args, device)
     else:
         print("Loading data ...")
-        dataloader, _ = get_loaders(
+        dataloader = get_loaders(
             args.dataset,
-            custom_data_path=args.custom_data_path,
             nsamples=args.nsamples,
             seed=args.seed,
             model_path=args.model_path,
@@ -83,9 +82,6 @@ def get_inps(model, data_iterable, args, dev, nsamples=None):
     layers = get_layers(model)
 
     nsamples = nsamples or args.nsamples
-
-    if hasattr(data_iterable, 'input_ids'):
-        data_iterable = data_iterable.input_ids
 
     if isinstance(data_iterable, torch.Tensor):
 
@@ -324,9 +320,6 @@ def quantize_nearest(model, args, dev):
 def perplexity_eval(model, testenc, args, dev):
     print(f"\nEvaluating perplexity for {args.dataset_name} dataset ...")
 
-    if hasattr(testenc, 'input_ids'):
-        testenc = testenc.input_ids
-
     nsamples = testenc.numel() // model.seqlen
 
     use_cache = model.config.use_cache
@@ -384,15 +377,14 @@ if __name__ == "__main__":
     parser.add_argument(
         "dataset",
         type=str,
-        choices=["custom", "wikitext2", "ptb", "c4"],
         default="none",
-        help="Where to extract calibration data from.",
+        help="Dataset name [c4, pajama, refinedweb, none, etc.] or path to data where to extract calibration data from.",
     )
     parser.add_argument(
         "--custom_data_path",
         type=str,
         default=None,
-        help="Path to load if specified.",
+        help="Path to load if specified. Deprecated",
     )
     parser.add_argument(
         "--seed", type=int, default=0, help="Seed for sampling the calibration data."
@@ -521,6 +513,12 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
+    if args.dataset == "custom":
+        print("WARNING: `--custom_data_path` argument and `--dataset=custom` option are DEPRECATED. ",
+             "Pass dataset path directly to `dataset` argument or use 'pajama', 'refinedweb'",
+             "See README.md for examples.")
+        args.dataset = args.custom_data_path 
+
     if args.wandb:
         assert has_wandb, "`wandb` not installed, try pip install `wandb`"
         args.exp_name = (
@@ -552,8 +550,8 @@ if __name__ == "__main__":
     if args.new_eval:
         datasets = ["wikitext2", "ptb-new", "c4-new"]
     for dataset in datasets:
-        dataloader, testloader = get_loaders(
-            dataset, seed=args.seed, model_path=args.model_path, seqlen=model.seqlen
+        testloader = get_loaders(
+            dataset, seed=args.seed, model_path=args.model_path, seqlen=model.seqlen, eval_mode=True,
         )
         args.dataset_name = dataset
         perplexity_eval(model, testloader, args, device)


### PR DESCRIPTION
updated, cleaner version of https://github.com/Vahe1994/SpQR/pull/20 

separate loading of train and eval data using param:eval_mode.
combining args.dataset and args.custom_data_path into one option
loading `pajama` and `refinedweb` using dataset option (since they both are included into this repo in a fixed location)
tests done in notebook

next step - separate train and eval loading to save time by avoiding lengthy train loading in eval stage.